### PR TITLE
Add action to pull updated conf files from FB

### DIFF
--- a/.github/workflows/flybase.yml
+++ b/.github/workflows/flybase.yml
@@ -1,0 +1,39 @@
+name: Update FlyBase Configuration
+on:
+  workflow_dispatch:
+    inputs:
+      FB-release:
+        required: true
+
+jobs:
+  update-conf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Alliance BLAST Service Configuration"
+        uses: actions/checkout@v4
+        with:
+          path: agr_blast_service_configuration
+
+      - name: "Checkout FlyBase BLAST Configuration"
+        uses: actions/checkout@v4
+        with:
+          repository: FlyBase/blast-db-configuration
+          path: flybase-blast-db-configuration
+
+      - name: Copy configuration files
+        run: |
+          cd flybase-blast-db-configuration/conf && \
+          tar cf - *.json | (cd ../../agr_blast_service_configuration/conf/FB/; tar xvBpf -)
+
+      - name: Create PR for updated FlyBase conf files
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: |
+            agr_blast_service_configuration/conf/FB/*.json
+          commit-message: ${{ github.event.inputs.FB-release }} BLAST config
+          branch: ${{ github.event.inputs.FB-release }}-blast-config-update
+          delete-branch: true
+          title: '[Update] ${{ github.event.inputs.FB-release }} BLAST config'
+          body: |
+            ${{ github.event.inputs.FB-release }} BLAST config
+          draft: false


### PR DESCRIPTION

This action will perform the following when manually triggered:

- Pull this Alliance blast conf repo
- Pull the FlyBase repo that manages their conf files
- Copy any FlyBase conf files into the Alliance repo.
- Create a branch w/ PR for any updated FlyBase files

