### PR TITLE
Upgrade create-pull-request action to v7

### DIFF
--- a/.github/workflows/flybase.yml
+++ b/.github/workflows/flybase.yml
@@ -24,7 +24,7 @@ jobs:
           tar cf - *.json | (cd ../../agr_blast_service_configuration/conf/FB/; tar xvBpf -)
 
       - name: Create PR for updated FlyBase conf files
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           add-paths: |
             agr_blast_service_configuration/conf/FB/*.json


### PR DESCRIPTION
This PR upgrades the create-pull-request GitHub action to v7. The FlyBase workflow is currently failing with no obvious changes on our end. Upgrading this prior to further debugging to see if this is a change on the GitHub side or this action.